### PR TITLE
Fix healthbar updating on every update call

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -16,7 +16,10 @@ export default class GUI {
 
   update() {
     // Update health bar
-    this.healthbar.setPercent(store.health / store.maxHealth * 100);
+    if (store.dirtyHealth) {
+      store.dirtyHealth = false;
+      this.healthbar.setPercent(store.health / store.maxHealth * 100);
+    }
   }
 
   render() {

--- a/src/player.js
+++ b/src/player.js
@@ -164,6 +164,8 @@ export default class Player {
     bullet.kill();
     this.ugh.play('', 0, 0.3, false);
 
+    store.dirtyHealth = true;
+
     // If health depleted, end the game
     if (store.health <= 0) {
       this.onDeath();
@@ -173,6 +175,8 @@ export default class Player {
   // When an enemy hits us
   onEnemyCollision(enemy) {
     store.health = store.health - enemy.damage / 50;
+
+    store.dirtyHealth = true;
 
     // If health depleted, end the game
     if (store.health <= 0) {

--- a/src/powerups.js
+++ b/src/powerups.js
@@ -27,6 +27,7 @@ export default class powerUps {
       store.maxHealth += 10;
       store.healthCost++;
       store.health = store.maxHealth;
+      store.dirtyHealth = true;
     } else {
       store.purchaseSound = false;
       console.log("You're out of money!");


### PR DESCRIPTION
Made the health bar only re-render when the health is dirty (needs to be re-rendered). 

In other words, we only draw the healthbar change when the health actually changes. This removes the flashing when loading a new state. That flashing actually occurs every time the healthbar moves, but is only really noticeable in state loads.